### PR TITLE
fixed: disabling the default constructor generation

### DIFF
--- a/include/strong_type.hpp
+++ b/include/strong_type.hpp
@@ -69,7 +69,7 @@ public:
   {
   }
   template <typename ... U,
-            typename = std::enable_if_t<std::is_constructible<T, U&&...>::value>>
+            typename = std::enable_if_t<std::is_constructible<T, U&&...>::value && (sizeof...(U) > 0)>>
   constexpr
   explicit
   type(


### PR DESCRIPTION
disabled the parameter-pack constructor template for zero-sized parameter packs so that it is handled separately by the has_default_constructible_tag logic

CI build job set up in a branch:  
[![Build Status](https://travis-ci.org/zavorka/strong_type.svg?branch=travis)](https://travis-ci.org/zavorka/strong_type)
